### PR TITLE
Fix: deploy to sonata

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -6,6 +6,13 @@ def pomConfig = {
 			distribution "repo"
 		}
 	}
+	developers {
+		developer {
+			id "noff"
+			name "Michael Kechinov"
+			email "mk@rees46.com"
+		}
+	}
 
 	scm {
 		connection "scm:git:github.com:rees46/android-sdk.git"


### PR DESCRIPTION
относится к https://github.com/rees46/planning/issues/1591