### PR TITLE
DEV-4256: fix stories layout on devices with display cutout

### DIFF
--- a/personalization-sdk/src/main/kotlin/com/personalization/stories/views/StoryDialog.kt
+++ b/personalization-sdk/src/main/kotlin/com/personalization/stories/views/StoryDialog.kt
@@ -4,6 +4,7 @@ import android.app.Dialog
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.Rect
+import android.os.Build
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -50,6 +51,10 @@ class StoryDialog(
 
         wlp.gravity = Gravity.CENTER
         wlp.flags = wlp.flags and WindowManager.LayoutParams.FLAG_BLUR_BEHIND.inv()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            wlp.layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
         window.attributes = wlp
         window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 

--- a/personalization-sdk/src/main/res/layout/dialog_stories.xml
+++ b/personalization-sdk/src/main/res/layout/dialog_stories.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/pull_dismiss_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:background="#000000"


### PR DESCRIPTION
Top progress timeline was hidden under the status bar / camera cutout on devices like Samsung Galaxy S24 Ultra. Apply system window insets to the dialog root and use SHORT_EDGES cutout mode so the content respects safe area.